### PR TITLE
Example of using Python's json module, other tips. 

### DIFF
--- a/esri2open.py
+++ b/esri2open.py
@@ -109,7 +109,7 @@ def wrtiteJSON(myOF):
                 
                 # The json module handles UTF-8 encoding and everything for
                 # you, and at C speed.
-                myStr += json.dump(properties)
+                myStr += json.dumps(properties)
 
              ##############################################
              #need to deal , blob, and raster at some point


### PR DESCRIPTION
Use Python's json module to serialize GeoJSON feature properties.

I've also made the code more efficient by eliminating redundant
function calls, using `in` tests against numerical types, only
getting a list of feature fields once. I've also deleted the
unnecessary `del` statements (you almost never have to do this in
Python) and the empty return statements. I also fixed identation.

Wish I could test this properly, but it should be functional and
hopefully helpful! These functions are clearly going to be a
big help to a lot of folks.
