### PR TITLE
CouchDB interop

### DIFF
--- a/esri2open/prepare.py
+++ b/esri2open/prepare.py
@@ -55,7 +55,7 @@ def prepareGeoJSON(outJSON,*args):
     
 def prepareJSON(outJSON,*args):
     out = open(outJSON,"wb")
-    out.write("""{"rows":[""")
+    out.write("""{"docs":[""")
     return out
 
 def prepareFile(outJSON,featureClass,fileType,includeGeometry):


### PR DESCRIPTION
for non-GeoJSON it currently uses the key 'rows' for all of the data, this was picked more or less at random, if that is changed to 'docs' then the data that is created can then be bulk imported into CouchDB. 
